### PR TITLE
[14.0][ADD] eng_account_show_reconcile_button: visibilidade do campo de entrada reconciliadas 

### DIFF
--- a/eng_account_show_reconcile_button/__manifest__.py
+++ b/eng_account_show_reconcile_button/__manifest__.py
@@ -1,0 +1,16 @@
+{
+    "name": "Visibility of the Reconciled Entries button.",
+    "summary": "Visibility of the Reconciled Entries button.",
+    "license": "AGPL-3",
+    "author": "Engenere",
+    "maintainers": ["cristianomafrajunior"],
+    "website": "https://github.com/Engenere/engenere-addons",
+    "version": "14.0.1.0.0",
+    "depends": [
+        "account",
+    ],
+    "data": [
+        "views/account_move_views.xml",
+    ],
+    "installable": True,
+}

--- a/eng_account_show_reconcile_button/views/account_move_views.xml
+++ b/eng_account_show_reconcile_button/views/account_move_views.xml
@@ -1,0 +1,12 @@
+<odoo>
+    <record id="view_move_form_extended" model="ir.ui.view">
+        <field name="name">account.move.form.extended</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <button name="open_reconcile_view" position="attributes">
+                <attribute name="attrs">{'invisible': ['|', ('move_type', '!=', 'entry'), ('id', '=', False)]}</attribute>
+            </button>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Objetivo dessa PR é trazer a visibilidade do botão mesmo quando que não houvesse linhas reconciliadas.
O botão só ira aparecer somente  depois de salvar.
Conforme era antes na versão 12.0


Podemos vê conforme a imagem:

![dfdd](https://github.com/Engenere/engenere-addons/assets/142639425/d71302e9-49de-4e95-924f-b31ba09d004d)

