### PR TITLE
[ADD] eng_report_danfe: imprimir danfe no modulo l10n_br_account para lib BrazilReportFiscal e  ErpBrasil.edoc

### DIFF
--- a/eng_report_danfe/__init__.py
+++ b/eng_report_danfe/__init__.py
@@ -1,0 +1,1 @@
+from . import reports

--- a/eng_report_danfe/__manifest__.py
+++ b/eng_report_danfe/__manifest__.py
@@ -1,0 +1,18 @@
+{
+    'name': 'Danfe Engenere Report',
+    'description': """
+        Generate a new danfe layout compatible with
+        OCA/l10n brazil for the BrazilFiscalReport
+        library and ErpBrasil.edoc""",
+    "version": "14.0.1.0.0",
+    'license': 'AGPL-3',
+    "maintainers": ["cristianomafrajunior"],
+    'author': 'Engenere',
+    'website': 'https://engenere.one',
+    'depends': [
+        "l10n_br_account",
+    ],
+    'data': [
+        "reports/danfe_report.xml"
+    ],
+}

--- a/eng_report_danfe/reports/__init__.py
+++ b/eng_report_danfe/reports/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_actions_report

--- a/eng_report_danfe/reports/danfe_report.xml
+++ b/eng_report_danfe/reports/danfe_report.xml
@@ -1,0 +1,12 @@
+<odoo>
+        <record id="report_engenere_danfe" model="ir.actions.report">
+            <field name="name">DANFE</field>
+            <field name="model">account.move</field>
+            <field name="report_type">qweb-pdf</field>
+            <field name="report_name">eng_report_danfe.main_template_danfe</field>
+            <field name="report_file">eng_report_danfe.main_template_danfe</field>
+            <field name="print_report_name">'%s' % (object.document_key)</field>
+            <field name="binding_model_id" ref="account.model_account_move"/>
+            <field name="binding_type">report</field>
+        </record>
+</odoo>

--- a/eng_report_danfe/reports/ir_actions_report.py
+++ b/eng_report_danfe/reports/ir_actions_report.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import base64
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def temp_xml_autorizacao(self, xml_string):
+        return super().temp_xml_autorizacao(xml_string=xml_string)
+
+    def _render_qweb_html(self, res_ids, data=None):
+        if self.report_name == "eng_report_danfe.main_template_danfe":
+            return super()._render_qweb_html(res_ids, data=data)
+
+    def _render_qweb_pdf(self, res_ids, data=None):
+        if self.report_name not in ["eng_report_danfe.main_template_danfe"]:
+            return super(IrActionsReport, self)._render_qweb_pdf(res_ids, data=data)
+
+        nfe = self.env["account.move"].search([("id", "in", res_ids)])
+
+        return self._render_danfe(nfe)
+
+    def _render_danfe(self, nfe):
+        return super()._render_danfe(nfe=nfe)


### PR DESCRIPTION
Adicionando Report de geração do Danfe no modulo l10n_br_account para gerar o danfe segue o Print: 

![dsdfdsds](https://github.com/Engenere/engenere-addons/assets/142639425/1ffaa11d-cdbc-4401-8b86-840a4029bc01)

Para configuração de qual biblioteca usar segue: Definições  > Empresa > Fiscal > NF-e > Danfe Library.
A partir dessa campo a empresa vai escolher a lib que ir usar, por padrão esta configurada BrazilFiscalReport.

![fddsfdsdfsdsdsxcsadqwe22](https://github.com/Engenere/engenere-addons/assets/142639425/c5afc773-38f7-4072-8cd5-1b45179b5501)

