### PR TITLE
[IMP] engenere_danfe_boleto: Adicionando impressão de boleto nos detalhes Fiscais + Impressão de Danfe e Boleto 

### DIFF
--- a/engenere_danfe_boleto/__init__.py
+++ b/engenere_danfe_boleto/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/engenere_danfe_boleto/__manifest__.py
+++ b/engenere_danfe_boleto/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "Engenere Danfe Boleto",
+    "summary": """
+        Print Boleto Button Visualization and Danfe + Boleto Generation
+    """,
+    "license": "AGPL-3",
+    "maintainers": ["cristianomafrajunior"],
+    "website": "https://engenere.one",
+    "version": "14.0.1.0.0",
+    "author": "Engenere",
+    "depends": [
+        "l10n_br_account",
+        "l10n_br_account_nfe",
+        "l10n_br_account_payment_brcobranca",
+    ],
+    "data": [
+        "views/l10n_br_fiscal_document_view.xml",
+        "views/account_move_view.xml",
+    ],
+    "installable": True,
+}

--- a/engenere_danfe_boleto/i18n/pt_BR.po
+++ b/engenere_danfe_boleto/i18n/pt_BR.po
@@ -1,0 +1,70 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* engenere_danfe_boleto
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-19 11:37+0000\n"
+"PO-Revision-Date: 2024-06-19 11:37+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: engenere_danfe_boleto
+#: model:ir.model.fields,field_description:engenere_danfe_boleto.field_l10n_br_fiscal_document__payment_method_code
+msgid "Code (Do Not Modify)"
+msgstr "Código (Não Modifique)"
+
+#. module: engenere_danfe_boleto
+#: model:ir.model.fields,field_description:engenere_danfe_boleto.field_account_move__display_name
+#: model:ir.model.fields,field_description:engenere_danfe_boleto.field_l10n_br_fiscal_document__display_name
+msgid "Display Name"
+msgstr "Nome exibido"
+
+#. module: engenere_danfe_boleto
+#: model:ir.model,name:engenere_danfe_boleto.model_l10n_br_fiscal_document
+msgid "Fiscal Document"
+msgstr "Documento Fiscal"
+
+#. module: engenere_danfe_boleto
+#: model:ir.model.fields,field_description:engenere_danfe_boleto.field_account_move__id
+#: model:ir.model.fields,field_description:engenere_danfe_boleto.field_l10n_br_fiscal_document__id
+msgid "ID"
+msgstr ""
+
+#. module: engenere_danfe_boleto
+#: model_terms:ir.ui.view,arch_db:engenere_danfe_boleto.view_move_danfe_boleto_form
+#: model_terms:ir.ui.view,arch_db:engenere_danfe_boleto.view_print_boleto
+msgid "Issue and Print"
+msgstr "Emitir e Imprimir"
+
+#. module: engenere_danfe_boleto
+#: model:ir.model,name:engenere_danfe_boleto.model_account_move
+msgid "Journal Entry"
+msgstr "Lançamento de Diário"
+
+#. module: engenere_danfe_boleto
+#: model:ir.model.fields,field_description:engenere_danfe_boleto.field_account_move____last_update
+#: model:ir.model.fields,field_description:engenere_danfe_boleto.field_l10n_br_fiscal_document____last_update
+msgid "Last Modified on"
+msgstr "Última modificação em"
+
+#. module: engenere_danfe_boleto
+#: model_terms:ir.ui.view,arch_db:engenere_danfe_boleto.view_print_boleto
+msgid "Print Boleto"
+msgstr "Imprimir boleto"
+
+#. module: engenere_danfe_boleto
+#: model:ir.model.fields,help:engenere_danfe_boleto.field_l10n_br_fiscal_document__payment_method_code
+msgid ""
+"This code is used in the code of the Odoo module that handles this payment "
+"method. Therefore, if you change it, the generation of the payment file may "
+"fail."
+msgstr ""
+"Este código é usado no código do módulo Odoo que trata desta forma de "
+"pagamento. Portanto, se você alterá-lo, a geração do arquivo poderá falhar."

--- a/engenere_danfe_boleto/models/__init__.py
+++ b/engenere_danfe_boleto/models/__init__.py
@@ -1,0 +1,2 @@
+from . import l10n_br_fiscal_document
+from . import account_move

--- a/engenere_danfe_boleto/models/account_move.py
+++ b/engenere_danfe_boleto/models/account_move.py
@@ -1,0 +1,13 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+
+    _inherit = "account.move"
+
+    def generate_combined_pdf(self):
+        self.ensure_one()
+        return self.fiscal_document_id.generate_combined_pdf()

--- a/engenere_danfe_boleto/models/l10n_br_fiscal_document.py
+++ b/engenere_danfe_boleto/models/l10n_br_fiscal_document.py
@@ -1,0 +1,70 @@
+# Copyright 2024 Engenere.one
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import base64
+from io import BytesIO
+
+from PyPDF2 import PdfFileMerger
+
+from odoo import fields, models
+
+
+class L10nBrFiscalDocument(models.Model):
+    _inherit = "l10n_br_fiscal.document"
+
+    payment_method_code = fields.Char(
+        related="move_ids.payment_mode_id.payment_method_code"
+    )
+
+    def view_boleto_pdf(self):
+        if not self.move_ids.file_boleto_pdf_id:
+            return self.move_ids.generate_boleto_pdf()
+        return self.move_ids._target_new_tab(self.move_ids.file_boleto_pdf_id)
+
+    def generate_combined_pdf(self):
+        if self.state == "em_digitacao":
+            self.move_ids.action_post()
+        if self.state == "a_enviar":
+            self.action_document_send()
+
+        if not self.move_ids.file_boleto_pdf_id:
+            return self.move_ids.generate_boleto_pdf()
+
+        if not self.file_report_id:
+            self.make_pdf()
+            return self.move_ids._target_new_tab(self.file_report_id)
+
+        boleto_pdf = base64.b64decode(self.move_ids.file_boleto_pdf_id.datas)
+        danfe_pdf = base64.b64decode(self.file_report_id.datas)
+
+        combined_pdf = self._combine_pdfs(boleto_pdf, danfe_pdf)
+        inv_number = self.document_number.zfill(8)
+        file_name = f"boleto_danfe_nf-{inv_number}.pdf"
+        combined_pdf_attachment = self.env["ir.attachment"].create(
+            {
+                "name": file_name,
+                "store_fname": file_name,
+                "res_model": self._name,
+                "res_id": self.id,
+                "datas": base64.b64encode(combined_pdf),
+                "mimetype": "application/pdf",
+                "type": "binary",
+            }
+        )
+
+        return {
+            "type": "ir.actions.act_url",
+            "url": "/web/content/{id}/{nome}".format(
+                id=combined_pdf_attachment.id, nome=combined_pdf_attachment.name
+            ),
+            "target": "new",
+        }
+
+    def _combine_pdfs(self, boleto_pdf, danfe_pdf):
+        merger = PdfFileMerger()
+        merger.append(BytesIO(danfe_pdf))
+        merger.append(BytesIO(boleto_pdf))
+        output = BytesIO()
+        merger.write(output)
+        output.seek(0)
+        return output.read()

--- a/engenere_danfe_boleto/views/account_move_view.xml
+++ b/engenere_danfe_boleto/views/account_move_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Engenere
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_move_danfe_boleto_form" model="ir.ui.view">
+        <field name="name">account.move.boleto.danfe.view</field>
+        <field name="model">account.move</field>
+        <field name="priority">99</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//header/button[@name='button_draft']" position="after">
+                <button
+          name="generate_combined_pdf"
+          type="object"
+          string="Issue and Print"
+          class="btn-primary"
+          attrs="{'invisible': [('payment_method_code', 'not in', ('240', '400', '500'))]}"
+        />
+            </xpath>
+            <xpath expr="//sheet" position="before">
+                <div
+          class="alert alert-danger"
+          role="alert"
+          attrs="{'invisible': [('xml_error_message', '=', False)]}"
+        >
+                    <strong>XML validation errors:</strong>
+                    <field name="xml_error_message" readonly="1" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/engenere_danfe_boleto/views/l10n_br_fiscal_document_view.xml
+++ b/engenere_danfe_boleto/views/l10n_br_fiscal_document_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2024 Engenere
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+    <record id="view_print_boleto" model="ir.ui.view">
+        <field name="name">account.move.cnab.view</field>
+        <field name="model">l10n_br_fiscal.document</field>
+        <field name="inherit_id" ref="l10n_br_fiscal.document_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <field name="payment_method_code" invisible="1" />
+                <button
+          name="view_boleto_pdf"
+          type="object"
+          string="Print Boleto"
+          class="btn-primary"
+          attrs="{'invisible': [('payment_method_code', 'not in', ('240', '400', '500'))]}"
+        />
+        />
+                <button
+          name="generate_combined_pdf"
+          type="object"
+          string="Issue and Print"
+          class="btn-primary"
+          attrs="{'invisible': [('payment_method_code', 'not in', ('240', '400', '500'))]}"
+        />
+        />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/engenere_danfe_boleto/odoo/addons/engenere_danfe_boleto
+++ b/setup/engenere_danfe_boleto/odoo/addons/engenere_danfe_boleto
@@ -1,0 +1,1 @@
+../../../../engenere_danfe_boleto

--- a/setup/engenere_danfe_boleto/setup.py
+++ b/setup/engenere_danfe_boleto/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Objetivo da PR

Trazer a impressão de boletos para os detalhes fiscais e também impressão de Danfe + Boleto juntos no mesmo PDF.

Segue o vídeo de impressão de boleto nos Detalhes Fiscais:

https://github.com/Engenere/engenere-addons/assets/142639425/82d24017-ae10-4309-a60a-316568e99671

Segue o vídeo de impressão de Danfe + Boleto nos Detalhes Fiscais e na Fatura:




https://github.com/Engenere/engenere-addons/assets/142639425/0f462dc0-1519-438e-bab8-222927dd776d




