### PR TITLE
[ADD] eng_cnab_filename module

### DIFF
--- a/eng_cnab_filename/__init__.py
+++ b/eng_cnab_filename/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/eng_cnab_filename/__manifest__.py
+++ b/eng_cnab_filename/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "CNAB Filename Sequence",
+    "summary": "Geração dos nomes de arquivo de remessa utilizando sequências do Odoo",
+    "license": "AGPL-3",
+    "author": "Engenere",
+    "maintainers": ["antoniospneto"],
+    "website": "https://engenere.one",
+    "version": "14.0.1.0.0",
+    "depends": ["l10n_br_account_payment_order"],
+    "data": [
+        "views/account_payment_mode.xml",
+    ],
+    "installable": True,
+}

--- a/eng_cnab_filename/models/__init__.py
+++ b/eng_cnab_filename/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_payment_order
+from . import account_payment_mode

--- a/eng_cnab_filename/models/account_payment_mode.py
+++ b/eng_cnab_filename/models/account_payment_mode.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class AccountPaymentMode(models.Model):
+    _inherit = "account.payment.mode"
+
+    filename_sequence_id = fields.Many2one(
+        comodel_name="ir.sequence",
+        string="Sequência do nome do arquivo",
+        tracking=True,
+    )

--- a/eng_cnab_filename/models/account_payment_order.py
+++ b/eng_cnab_filename/models/account_payment_order.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class AccountPaymentOrder(models.Model):
+    _inherit = "account.payment.order"
+
+    def get_file_name(self, cnab_type):
+        """
+        Sobrescreve a lógica para a criação do nome a partir do sequenciador.
+        """
+        sequence = self.payment_mode_id.filename_sequence_id
+        if sequence:
+            filename = f"{sequence.next_by_id()}.REM"
+        else:
+            filename = super().get_file_name(cnab_type)
+        return filename

--- a/eng_cnab_filename/views/account_payment_mode.xml
+++ b/eng_cnab_filename/views/account_payment_mode.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="eng_cnab_filename_payment_mode_form" model="ir.ui.view">
+        <field name="name">eng_cnab_filename.payment_mode.form</field>
+        <field name="model">account.payment.mode</field>
+        <field name="priority">99</field>
+        <field
+      name="inherit_id"
+      ref="l10n_br_account_payment_order.l10n_br_account_payment_mode_form"
+    />
+        <field name="arch" type="xml">
+            <field name="cnab_sequence_id" position="after">
+                <field name="filename_sequence_id" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/setup/eng_cnab_filename/odoo/addons/eng_cnab_filename
+++ b/setup/eng_cnab_filename/odoo/addons/eng_cnab_filename
@@ -1,0 +1,1 @@
+../../../../eng_cnab_filename

--- a/setup/eng_cnab_filename/setup.py
+++ b/setup/eng_cnab_filename/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Pequeno módulo para utilizar sequenciador nativo do odoo na geração do nome do arquivo de remessa CNAB.

O banco itáu só aceita no maximo 8 caracteres no nome do arquivo.