### PR TITLE
[14.0][ADD] eng_customer_fiscal_comments: customer fiscal comments

### DIFF
--- a/eng_customer_fiscal_comments/__init__.py
+++ b/eng_customer_fiscal_comments/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/eng_customer_fiscal_comments/__manifest__.py
+++ b/eng_customer_fiscal_comments/__manifest__.py
@@ -1,0 +1,23 @@
+{
+    "name": "Customer Fiscal Comments ",
+    "summary": """
+    The Customer Fiscal Comments module enables users
+    to add tax-related comments to customer profiles,
+    which are displayed on invoices for better compliance.
+    """,
+    "license": "AGPL-3",
+    "author": "Engenere",
+    "maintainers": ["cristianomafrajunior"],
+    "website": "https://engenere.one",
+    "category": "Services/Industry",
+    "version": "14.0.1.0.0",
+    "development_status": "Beta",
+    "depends": [
+        "account",
+        "l10n_br_nfe",
+    ],
+    "data": [
+        "views/res_partner_views.xml",
+    ],
+    "installable": True,
+}

--- a/eng_customer_fiscal_comments/i18n/pt_BR.po
+++ b/eng_customer_fiscal_comments/i18n/pt_BR.po
@@ -1,0 +1,50 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* eng_customer_fiscal_comments
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-10-14 20:17+0000\n"
+"PO-Revision-Date: 2024-10-14 20:17+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: eng_customer_fiscal_comments
+#: model:ir.model,name:eng_customer_fiscal_comments.model_res_partner
+msgid "Contact"
+msgstr "Contato"
+
+#. module: eng_customer_fiscal_comments
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_l10n_br_fiscal_document_mixin_methods__display_name
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Nome de exibição"
+
+#. module: eng_customer_fiscal_comments
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_res_partner__fiscal_comments
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_res_users__fiscal_comments
+msgid "Fiscal Comments"
+msgstr "Comentários Fiscais"
+
+#. module: eng_customer_fiscal_comments
+#: model:ir.model,name:eng_customer_fiscal_comments.model_l10n_br_fiscal_document_mixin_methods
+msgid "Fiscal Document Mixin Methods"
+msgstr ""
+
+#. module: eng_customer_fiscal_comments
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_l10n_br_fiscal_document_mixin_methods__id
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_res_partner__id
+msgid "ID"
+msgstr "ID"
+
+#. module: eng_customer_fiscal_comments
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_l10n_br_fiscal_document_mixin_methods____last_update
+#: model:ir.model.fields,field_description:eng_customer_fiscal_comments.field_res_partner____last_update
+msgid "Last Modified on"
+msgstr "Última atualização em"

--- a/eng_customer_fiscal_comments/models/__init__.py
+++ b/eng_customer_fiscal_comments/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner
+from . import document_mixin_methods

--- a/eng_customer_fiscal_comments/models/document_mixin_methods.py
+++ b/eng_customer_fiscal_comments/models/document_mixin_methods.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class DocumentMixinMethods(models.AbstractModel):
+    _inherit = "l10n_br_fiscal.document.mixin.methods"
+
+    def _document_comment(self):
+        for d in self:
+            if d.partner_id:
+                d.manual_fiscal_additional_data = d.partner_id.fiscal_comments
+                super()._document_comment()
+            else:
+                d.manual_fiscal_additional_data = False

--- a/eng_customer_fiscal_comments/models/res_partner.py
+++ b/eng_customer_fiscal_comments/models/res_partner.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    fiscal_comments = fields.Text()

--- a/eng_customer_fiscal_comments/views/res_partner_views.xml
+++ b/eng_customer_fiscal_comments/views/res_partner_views.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <record id="eng_customer_fiscal_comments_view" model="ir.ui.view">
+        <field name="name">res.partner.property.form.inherit</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath
+        expr="//field[@name='property_account_position_id']"
+        position="after"
+      >
+                <field name="fiscal_comments" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/eng_customer_fiscal_comments/odoo/addons/eng_customer_fiscal_comments
+++ b/setup/eng_customer_fiscal_comments/odoo/addons/eng_customer_fiscal_comments
@@ -1,0 +1,1 @@
+../../../../eng_customer_fiscal_comments

--- a/setup/eng_customer_fiscal_comments/setup.py
+++ b/setup/eng_customer_fiscal_comments/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
## Objetivo da PR 

Ter um campo no cadastro do Cliente responsavél por ter informações fiscais que serão informada na seção de Dados Adicionas da Nota-Fiscal.
Em vez de criar um campo novo eu aproveitei o campo **manual_fiscal_additional_data** que é responsavél por colocar comentario manual.

Aqui nesse video pode vê o resultado:

https://github.com/user-attachments/assets/f1f9723c-f600-4b81-a737-bedb8e83326d

cc @antoniospneto @felipemotter 



