### PR TITLE
[16.0][IMP] eng_consent_letter_report: add own_number column to report

### DIFF
--- a/eng_consent_letter_report/__manifest__.py
+++ b/eng_consent_letter_report/__manifest__.py
@@ -6,7 +6,11 @@
     "maintainers": ["cristianomafrajunior"],
     "website": "https://github.com/Engenere/engenere-addons",
     "version": "16.0.1.0.0",
-    "depends": ["l10n_br_account", "account_reconcile_oca"],
+    "depends": [
+        "l10n_br_account",
+        "l10n_br_account_payment_order",
+        "account_reconcile_oca",
+    ],
     "data": [
         "report/account_move_line_template.xml",
         "report/account_move_line_report.xml",

--- a/eng_consent_letter_report/report/account_move_line_template.xml
+++ b/eng_consent_letter_report/report/account_move_line_template.xml
@@ -15,6 +15,7 @@
                         <thead>
                             <tr>
                                 <th style="font-size: 20px;">Duplicata</th>
+                                <th style="font-size: 20px;">Nosso Número</th>
                                 <th style="font-size: 20px;">Valor</th>
                                 <th style="font-size: 20px;">Vencimento</th>
                             </tr>
@@ -29,6 +30,7 @@
                                     />
                                     <tr>
                                         <td><span t-field="doc.name" /></td>
+                                        <td><span t-field="doc.own_number" /></td>
                                         <td><span t-field="doc.balance" /></td>
                                         <td><span t-field="doc.date_maturity" /></td>
                                     </tr>


### PR DESCRIPTION
## Resumo

Adiciona a coluna "Nosso Número" (`own_number`) na tabela da Carta de Anuência, entre "Duplicata" e "Valor".

## Solução

- Adicionada a coluna "Nosso Número" no header e nas linhas da tabela do template QWeb.
- Adicionada dependência `l10n_br_account_payment_order` no manifesto, pois é o módulo que define o campo `own_number` em `account.move.line`.