### PR TITLE
[16.0][ADD] eng_stock_picking_sales_purchase_readonly: smoke-test fiscal do faturista

### DIFF
--- a/eng_stock_picking_sales_purchase_readonly/tests/__init__.py
+++ b/eng_stock_picking_sales_purchase_readonly/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_picking_readonly
+from . import test_faturista_invoice

--- a/eng_stock_picking_sales_purchase_readonly/tests/test_faturista_invoice.py
+++ b/eng_stock_picking_sales_purchase_readonly/tests/test_faturista_invoice.py
@@ -1,0 +1,94 @@
+from odoo.exceptions import AccessError
+from odoo.tests import tagged
+from odoo.tests.common import new_test_user
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestFaturistaInvoicePost(AccountTestInvoicingCommon):
+    """The picking lockdown turns stock.picking/move/move.line read-only for
+    the invoicing role. This must NOT bleed into the invoicing flow: a
+    faturista (and Bruna's full multi-hat stack) has to keep posting customer
+    invoices for stockable products without hitting an AccessError on stock.
+
+    The Trento companies run manual/periodic valuation (anglo_saxon=False), so
+    posting a customer invoice never touches stock.valuation.layer — this test
+    locks that invariant against a regression in the lockdown ACLs. (Real-time
+    valuation would route the post through stock.valuation.layer, which needs a
+    stock role; that configuration is out of scope by decision.)
+    """
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+        cls.company = cls.company_data["company"]
+        cls.stockable = cls.env["product.product"].create(
+            {
+                "name": "Stockable Invoiceable",
+                "type": "product",
+                "invoice_policy": "order",
+                "categ_id": cls.env.ref("product.product_category_all").id,
+            }
+        )
+        cls.faturista = new_test_user(
+            cls.env,
+            login="inv_faturista",
+            groups="base.group_user,account.group_account_invoice",
+            company_id=cls.company.id,
+            company_ids=[(6, 0, [cls.company.id])],
+        )
+        # Bruna's real hat stack: salesman + buyer + invoicing, no stock role.
+        cls.multi_hat = new_test_user(
+            cls.env,
+            login="inv_multi_hat",
+            groups=(
+                "base.group_user,"
+                "sales_team.group_sale_salesman,"
+                "purchase.group_purchase_user,"
+                "account.group_account_invoice"
+            ),
+            company_id=cls.company.id,
+            company_ids=[(6, 0, [cls.company.id])],
+        )
+
+    def _sale_with_draft_invoice(self):
+        """Build a confirmed sale of a stockable product (which creates a
+        delivery picking) and its draft customer invoice, as the back office
+        would hand it to the invoicing clerk."""
+        order = (
+            self.env["sale.order"]
+            .with_company(self.company)
+            .create(
+                {
+                    "partner_id": self.partner_a.id,
+                    "order_line": [
+                        (0, 0, {"product_id": self.stockable.id, "product_uom_qty": 3})
+                    ],
+                }
+            )
+        )
+        order.action_confirm()
+        self.assertTrue(
+            order.picking_ids,
+            "confirming a stockable sale must create a delivery picking",
+        )
+        invoice = order._create_invoices()
+        self.assertEqual(invoice.state, "draft")
+        return order, invoice
+
+    def test_faturista_posts_invoice_without_stock_error(self):
+        order, invoice = self._sale_with_draft_invoice()
+        invoice.with_user(self.faturista).action_post()
+        self.assertEqual(invoice.state, "posted")
+        # The lockdown still holds in the very same scenario: the clerk who
+        # just posted the invoice cannot touch the delivery picking.
+        with self.assertRaises(AccessError):
+            order.picking_ids[:1].with_user(self.faturista).write({"note": "leak"})
+
+    def test_multi_hat_posts_invoice_without_stock_error(self):
+        order, invoice = self._sale_with_draft_invoice()
+        invoice.with_user(self.multi_hat).action_post()
+        self.assertEqual(invoice.state, "posted")
+        with self.assertRaises(AccessError):
+            order.picking_ids[:1].with_user(self.multi_hat).write({"note": "leak"})


### PR DESCRIPTION
## Resumo

Adiciona o **smoke-test fiscal** que ficou pendente antes do merge da #88. Garante que o lockdown de transferências (que torna `stock.picking`/`move`/`move.line` somente-leitura para vendas/compras/faturamento) **não vaza** para o fluxo de faturamento.

## O que cobre

`tests/test_faturista_invoice.py` → `TestFaturistaInvoicePost` (herda `AccountTestInvoicingCommon`):

- **Faturista puro** (`account.group_account_invoice`, sem `stock.group_stock_user`) confirma uma venda de produto estocável (que gera picking), e **posta** a fatura de cliente **sem `AccessError`** em estoque.
- **Multi-hat** (vendedor + comprador + faturista — a persona real da Bruna) faz o mesmo.
- Em ambos, no mesmo cenário, confirma que o lockdown continua valendo: o usuário que acabou de postar a fatura **não consegue** editar o picking.

## Por que funciona

A Trento opera com **valoração de estoque manual/periódica** (`anglo_saxon_accounting=False` nas 3 companies, `property_valuation='manual_periodic'` em todas as categorias). Nesse modo, postar uma fatura de cliente **não** passa por `stock.valuation.layer` (que exigiria papel de estoque). O único ponto onde o post tocaria estoque é a valoração em tempo real/anglo-saxão — configuração que a Trento não usa e está fora de escopo por decisão.

Teste cirúrgico de propósito: não depende de `l10n_br` (o `l10n_br_account._post` só chama `action_document_confirm()`, não escreve em estoque), evitando setup fiscal/SEFAZ.

## Test plan

- [x] `inv testdb` — 34 testes no módulo, 0 falhas
- [x] Classe nova isolada: 2/2 verde
- [x] Pre-commit limpo
- [x] Revisado pelo Codex (sem findings técnicos)

> Observação: sem código de produção novo (só teste), então não há patch coverage a medir.