### PR TITLE
[16.0][FIX] eng_allows_duplicate_cnpj_ie: neutralize the renamed constraint

### DIFF
--- a/eng_allows_duplicate_cnpj_ie/models/res_partner.py
+++ b/eng_allows_duplicate_cnpj_ie/models/res_partner.py
@@ -14,3 +14,12 @@ class Partner(models.Model):
         Permitir CNPJs e IEs duplicados
         """
         return
+
+    @api.constrains("vat", "l10n_br_ie_code")
+    def _check_cnpj_l10n_br_ie_code(self):
+        """
+        Mesma desativação para a constraint que substituiu a de cima no
+        l10n_br_base: sem este override o módulo deixou de ter efeito, e
+        cadastros com CNPJ repetido voltaram a ser recusados.
+        """
+        return


### PR DESCRIPTION
## Resumo

O módulo parou de fazer efeito: o `l10n_br_base` substituiu a constraint `_check_cnpj_inscr_est` por `_check_cnpj_l10n_br_ie_code` (agora sobre `vat` e `l10n_br_ie_code`), e este módulo só neutralizava a antiga. Resultado: **CNPJ duplicado voltou a ser recusado** em qualquer base com l10n_br_base atual — e o próprio teste do módulo quebrou.

Descoberto porque a CI do repo (que instala o l10n_br_base do PyPI, versão flutuante) ficou vermelha no primeiro run desde 15/jun: `TestPartnerCNPJIE.test_create_partner_validation` → `ValidationError: There is already a partner Test Company (ID 80) with this CNPJ`.

## Solução

Neutralizar também a constraint nova, mantendo o override antigo para bases ainda em release anterior.

Red-green com o teste que já existe no módulo: reproduzido local (1 erro) antes do fix, verde depois — mesma base, só o override adicionado.

Uso de IA: com assistência de Claude (trailer `Assisted-by:` no commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)